### PR TITLE
Add game filtering by category and publisher

### DIFF
--- a/.github/instructions/blazor.instructions.md
+++ b/.github/instructions/blazor.instructions.md
@@ -93,6 +93,65 @@ Blazor is used for page routing, layouts, and interactive components. All UI is 
 - Use `@inject HttpClient Http` for API calls
 - Handle loading states and errors gracefully
 
+### SSR + Interactive Dual-Render Behaviour
+
+Components with `@rendermode InteractiveServer` render **twice**:
+
+1. **SSR pass** — Blazor runs `OnInitializedAsync` on the server and sends the full HTML to the browser (including dropdown options, lists, etc.). `OnAfterRenderAsync` does **NOT** run during SSR.
+2. **Interactive pass** — After the page loads, Blazor's SignalR circuit connects in the browser and the component becomes interactive. `OnInitializedAsync` runs again, and `OnAfterRenderAsync(firstRender: true)` runs for the first time.
+
+This has two important implications:
+
+**`@onchange` / event handlers only work after the interactive pass.** During SSR the HTML looks complete but no event handlers are wired. Blazor's JavaScript intercepts DOM events and sends them to the server via SignalR — if the circuit isn't connected yet, events fire but nothing handles them.
+
+**`OnAfterRenderAsync(firstRender: true)` is the only reliable signal that the circuit is connected.** Use it to set a `data-interactive` attribute so tests and other code can detect readiness:
+
+```razor
+@* Container div signals circuit readiness for tests *@
+<div data-testid="my-interactive-panel" data-interactive="@(_isInteractive ? "true" : null)">
+    @* content *@
+</div>
+
+@code {
+    private bool _isInteractive = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _isInteractive = true;
+            StateHasChanged();
+        }
+    }
+}
+```
+
+Any E2E test that interacts with an `@rendermode InteractiveServer` component **must** wait for `data-interactive="true"` before firing events. See `playwright.instructions.md` for the `WaitForInteractiveAsync()` helper pattern.
+
+### Client Models Must Mirror the API JSON Shape
+
+Client-side models in `client/TailspinToys.Web/Models/` must exactly match the JSON returned by the API. Before writing a client model, check the server model's `ToDict()` method to understand the JSON structure.
+
+- **Nested API objects must be nested client classes.** The API returns `publisher: { id, name }` — the client model needs a `Publisher` class, not a flat `[JsonPropertyName("publisher_name")] string PublisherName`.
+- **Never add flat `[JsonPropertyName]` properties for relationship data** — they will always be `null` because the JSON key doesn't exist.
+
+```csharp
+// ✅ Correct — matches nested JSON: { "publisher": { "id": 1, "name": "Acme" } }
+public class Game
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = "";
+    public Publisher? Publisher { get; set; }   // populated from nested JSON
+    public Category? Category { get; set; }      // populated from nested JSON
+}
+
+public class Publisher { public int Id { get; set; } public string Name { get; set; } = ""; }
+
+// ❌ Wrong — "publisher_name" key does not exist in the API response; always null
+[JsonPropertyName("publisher_name")]
+public string? PublisherName { get; set; }
+```
+
 ### Data Fetching
 
 ```razor

--- a/.github/instructions/playwright.instructions.md
+++ b/.github/instructions/playwright.instructions.md
@@ -49,10 +49,52 @@ await Expect(Page).ToHaveURLAsync("/game/1");
 ### Important Rules
 
 - **NEVER** use `Task.Delay` or hard-coded waits
+- **NEVER** use `WaitForSelectorAsync` to wait after an interaction — if the element is already in the DOM it returns immediately, causing flaky tests. Use `Expect()` assertions instead (see below).
 - Use descriptive test method names
 - Take screenshots only on failure
 - Use `data-testid` for all interactive elements
 - All test classes should extend `PlaywrightTestBase`
+
+### Waiting After Interactions
+
+After clicking, selecting, or any user interaction, **always wait for the semantic consequence** using auto-retrying `Expect()` assertions. Never use `WaitForSelectorAsync` or `WaitForLoadStateAsync` as a proxy for "loading finished" — if the element is already present they return immediately.
+
+```csharp
+// ✅ Correct — waits for the filter to take effect (auto-retries until true)
+await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = "1" });
+await Expect(Page.GetByTestId("game-category").First).ToContainTextAsync("Strategy");
+
+// ✅ Correct — waits for count to match (auto-retries)
+await Page.GetByTestId("filter-clear-button").ClickAsync();
+await Expect(Page.GetByTestId("game-card")).ToHaveCountAsync(initialCount);
+
+// ❌ Wrong — returns immediately if games-grid is already in the DOM
+await Page.WaitForSelectorAsync("[data-testid='games-grid']");
+```
+
+### Blazor Interactive Server Testing
+
+Components with `@rendermode InteractiveServer` are rendered twice: once by SSR (initial HTML, no event handlers) and again when Blazor's SignalR circuit connects. DOM elements can be present in the page before the circuit is ready, so interacting with them immediately after navigation may have no effect.
+
+**Always wait for the component's `data-interactive="true"` attribute before interacting:**
+
+```csharp
+/// <summary>Waits for the filter panel's Blazor circuit to be connected.</summary>
+private async Task WaitForInteractiveAsync(string testId = "game-filter-panel")
+{
+    await Page.Locator($"[data-testid='{testId}'][data-interactive='true']")
+              .WaitForAsync(new() { Timeout = 15000 });
+}
+```
+
+Call this before any `SelectOptionAsync`, `ClickAsync`, or other interactions on Blazor interactive components:
+
+```csharp
+await Page.GotoAsync("/");
+await WaitForInteractiveAsync("game-filter-panel");
+// Now safe to interact with the filter dropdowns
+await Page.GetByTestId("filter-category").SelectOptionAsync(...);
+```
 
 ### Available Test IDs
 

--- a/.github/instructions/playwright.instructions.md
+++ b/.github/instructions/playwright.instructions.md
@@ -71,3 +71,7 @@ await Expect(Page).ToHaveURLAsync("/game/1");
 - `back-game-button` - Support This Game button
 - `about-section` - About page section
 - `about-heading` - About page heading
+- `game-filter-panel` - Filter panel container on the games list page
+- `filter-category` - Category filter dropdown (select element)
+- `filter-publisher` - Publisher filter dropdown (select element)
+- `filter-clear-button` - Clear all filters button (visible only when a filter is active)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ return Results.BadRequest(new { error = "Invalid input" });
 
 **Structure** (`server/TailspinToys.Api.Tests/`)
 - Use xUnit with `WebApplicationFactory<Program>`
-- Use InMemoryDatabase for test isolation
+- Use **file-based SQLite** (not InMemoryDatabase) for route/integration tests — see `dotnet-tests.instructions.md` for the full pattern
 - Define test data as class constants
 - Implement `IDisposable` for cleanup
 
@@ -165,13 +165,19 @@ The project includes comprehensive Playwright E2E tests written in C# with xUnit
 
 **Playwright Patterns**
 - Use role-based locators: `getByRole`, `getByLabel`, `getByText`
-- Use `test.step()` for grouping
-- Auto-retrying assertions: `await expect(locator).toHaveText()`
-- **NEVER** use `waitForTimeout` or hard-coded waits
+- Auto-retrying assertions: `await Expect(locator).ToContainTextAsync("...")`
+- **NEVER** use `Task.Delay`, hard-coded waits, or `WaitForSelectorAsync` after an interaction — use `Expect()` to assert semantic consequences instead
+- For `@rendermode InteractiveServer` components, wait for `data-interactive="true"` before interacting — see `playwright.instructions.md` for the `WaitForInteractiveAsync()` helper
 
 **Testability Requirement**
 - **ALL** interactive elements MUST have `data-testid` attributes
 - Use descriptive IDs: `data-testid="game-card"`
+
+**Client Model Guidelines**
+- Client models live in `client/TailspinToys.Web/Models/`
+- Before writing a client model, check the server model's `ToDict()` method to understand the exact JSON shape
+- Nested API objects (`publisher: {id, name}`) → nested client classes; **never** use flat `[JsonPropertyName("publisher_name")]` properties for relationship data (those keys don't exist in the API response and will always deserialise as `null`)
+- See `.github/instructions/blazor.instructions.md` for the full pattern
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Start with [workshop/00-prereqs.md](./workshop/00-prereqs.md) for the full setup
 
 Or, if just want to run the app...
 
+## Features
+
+- **Game listing** — Browse all crowdfunded games with titles, descriptions, categories, publishers, and star ratings
+- **Game filtering** — Filter the game list by category and/or publisher using the dropdown controls; filters can be combined and cleared with a single button
+- **Game details** — View full details for any game and support it with the "Support This Game" button
+
 ## Launch the site
 
 A script file has been created to launch the site. You can run it by:

--- a/client/TailspinToys.E2E/FilterTests.cs
+++ b/client/TailspinToys.E2E/FilterTests.cs
@@ -43,8 +43,10 @@ public class FilterTests : PlaywrightTestBase
         var firstCategoryValue = await categoryOptions[1].GetAttributeAsync("value");
         await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = firstCategoryValue });
 
-        // Wait for the grid to refresh
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        // Wait for the filter to apply: the first category badge must show the selected category.
+        // This auto-retries and proves the API call completed with filtered results.
+        await Expect(Page.GetByTestId("game-category").First)
+            .ToContainTextAsync(firstCategoryText, new() { Timeout = 15000 });
 
         // Every visible category badge must match the selected category
         var categoryBadges = Page.GetByTestId("game-category");
@@ -75,8 +77,9 @@ public class FilterTests : PlaywrightTestBase
         var firstPublisherValue = await publisherOptions[1].GetAttributeAsync("value");
         await publisherSelect.SelectOptionAsync(new SelectOptionValue { Value = firstPublisherValue });
 
-        // Wait for the grid to refresh
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        // Wait for the filter to apply: the first publisher badge must show the selected publisher.
+        await Expect(Page.GetByTestId("game-publisher").First)
+            .ToContainTextAsync(firstPublisherText, new() { Timeout = 15000 });
 
         // Every visible publisher badge must match the selected publisher
         var publisherBadges = Page.GetByTestId("game-publisher");
@@ -172,17 +175,16 @@ public class FilterTests : PlaywrightTestBase
         Assert.True(categoryOptions.Count > 1, "Category dropdown must have options beyond 'All Categories'");
 
         await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = await categoryOptions[1].GetAttributeAsync("value") });
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        // Wait for filter to apply — clear button appears when selectedCategoryId != 0
+        await Expect(Page.GetByTestId("filter-clear-button")).ToBeVisibleAsync(new() { Timeout = 15000 });
 
         // Click the clear button (single click — triggers single load)
         await Page.GetByTestId("filter-clear-button").ClickAsync();
 
-        // Wait for the full list to be restored
-        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
-
-        // Full count should be restored and clear button hidden
-        var restoredCount = await Page.GetByTestId("game-card").CountAsync();
-        Assert.Equal(initialCount, restoredCount);
+        // Wait for all games to be restored.
+        // WaitForSelectorAsync would return immediately (games-grid already visible), so use
+        // ToHaveCountAsync which retries until the count matches the initial unfiltered count.
+        await Expect(Page.GetByTestId("game-card")).ToHaveCountAsync(initialCount, new() { Timeout = 15000 });
         await Expect(Page.GetByTestId("filter-clear-button")).Not.ToBeVisibleAsync();
     }
 
@@ -209,14 +211,15 @@ public class FilterTests : PlaywrightTestBase
     }
 
     /// <summary>
-    /// Waits for the Blazor interactive circuit to connect and populate filter dropdown options.
-    /// The filter panel uses @rendermode InteractiveServer, so options are loaded asynchronously
-    /// after the SignalR circuit connects — waiting for games-grid alone is not sufficient.
+    /// Waits for the Blazor interactive circuit to connect and event handlers to be wired up.
+    /// <c>data-interactive="true"</c> is set by <c>OnAfterRenderAsync(firstRender: true)</c>
+    /// in GameFilterPanel, which only runs in interactive mode — NOT during SSR.
+    /// Waiting for this attribute ensures <c>@onchange</c> events are properly handled.
     /// </summary>
     private async Task WaitForFilterOptionsAsync()
     {
-        await Expect(Page.GetByTestId("filter-category").Locator("option").Nth(1))
-            .ToBeAttachedAsync(new() { Timeout = 15000 });
+        await Expect(Page.GetByTestId("game-filter-panel"))
+            .ToHaveAttributeAsync("data-interactive", "true", new() { Timeout = 15000 });
     }
 
     private static ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);

--- a/client/TailspinToys.E2E/FilterTests.cs
+++ b/client/TailspinToys.E2E/FilterTests.cs
@@ -24,9 +24,10 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldFilterGamesByCategory()
     {
-        // Navigate to homepage and wait for games to load
+        // Navigate to homepage and wait for games and filter options to load
         await Page.GotoAsync("/");
         await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForFilterOptionsAsync();
 
         // Verify categories dropdown loaded real options
         var categorySelect = Page.GetByTestId("filter-category");
@@ -59,9 +60,10 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldFilterGamesByPublisher()
     {
-        // Navigate to homepage and wait for games to load
+        // Navigate to homepage and wait for games and filter options to load
         await Page.GotoAsync("/");
         await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForFilterOptionsAsync();
 
         // Verify publishers dropdown loaded real options
         var publisherSelect = Page.GetByTestId("filter-publisher");
@@ -90,9 +92,10 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldFilterGamesByCategoryAndPublisherCombined()
     {
-        // Navigate to homepage and wait for games to load
+        // Navigate to homepage and wait for games and filter options to load
         await Page.GotoAsync("/");
         await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForFilterOptionsAsync();
 
         var categorySelect = Page.GetByTestId("filter-category");
         var publisherSelect = Page.GetByTestId("filter-publisher");
@@ -134,9 +137,10 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldShowClearButtonOnlyWhenFilterIsActive()
     {
-        // Navigate to homepage and wait for games to load
+        // Navigate to homepage and wait for games and filter options to load
         await Page.GotoAsync("/");
         await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForFilterOptionsAsync();
 
         // Clear button should not be visible with no filters
         await Expect(Page.GetByTestId("filter-clear-button")).Not.ToBeVisibleAsync();
@@ -153,9 +157,10 @@ public class FilterTests : PlaywrightTestBase
     [Fact]
     public async Task ShouldClearFiltersAndRestoreAllGames()
     {
-        // Navigate to homepage and wait for games to load
+        // Navigate to homepage and wait for games and filter options to load
         await Page.GotoAsync("/");
         await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+        await WaitForFilterOptionsAsync();
 
         // Record initial full count
         var initialCount = await Page.GetByTestId("game-card").CountAsync();
@@ -201,6 +206,17 @@ public class FilterTests : PlaywrightTestBase
 
         await publisherSelect.FocusAsync();
         await Expect(publisherSelect).ToBeFocusedAsync();
+    }
+
+    /// <summary>
+    /// Waits for the Blazor interactive circuit to connect and populate filter dropdown options.
+    /// The filter panel uses @rendermode InteractiveServer, so options are loaded asynchronously
+    /// after the SignalR circuit connects — waiting for games-grid alone is not sufficient.
+    /// </summary>
+    private async Task WaitForFilterOptionsAsync()
+    {
+        await Expect(Page.GetByTestId("filter-category").Locator("option").Nth(1))
+            .ToBeAttachedAsync(new() { Timeout = 15000 });
     }
 
     private static ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);

--- a/client/TailspinToys.E2E/FilterTests.cs
+++ b/client/TailspinToys.E2E/FilterTests.cs
@@ -1,0 +1,208 @@
+// E2E tests for the game filtering feature.
+// Verifies filter panel visibility, filtering by category and publisher,
+// combined filters, and clearing filters to restore the full game list.
+
+using Microsoft.Playwright;
+
+namespace TailspinToys.E2E;
+
+public class FilterTests : PlaywrightTestBase
+{
+    [Fact]
+    public async Task ShouldDisplayFilterPanelOnHomePage()
+    {
+        // Navigate to homepage and wait for the page to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Verify filter panel and its controls are visible
+        await Expect(Page.GetByTestId("game-filter-panel")).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId("filter-category")).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId("filter-publisher")).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task ShouldFilterGamesByCategory()
+    {
+        // Navigate to homepage and wait for games to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Verify categories dropdown loaded real options
+        var categorySelect = Page.GetByTestId("filter-category");
+        var categoryOptions = await categorySelect.Locator("option").AllAsync();
+        Assert.True(categoryOptions.Count > 1, "Category dropdown must have options beyond 'All Categories'");
+
+        // Collect game titles before filtering
+        var titlesBefore = await Page.GetByTestId("game-title").AllInnerTextsAsync();
+        Assert.NotEmpty(titlesBefore);
+
+        // Select the first real category
+        var firstCategoryText = (await categoryOptions[1].InnerTextAsync()).Trim();
+        var firstCategoryValue = await categoryOptions[1].GetAttributeAsync("value");
+        await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = firstCategoryValue });
+
+        // Wait for the grid to refresh
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Every visible category badge must match the selected category
+        var categoryBadges = Page.GetByTestId("game-category");
+        var badgeCount = await categoryBadges.CountAsync();
+        Assert.True(badgeCount > 0, "Filtered results must include at least one game with a category badge");
+
+        for (var i = 0; i < badgeCount; i++)
+        {
+            await Expect(categoryBadges.Nth(i)).ToContainTextAsync(firstCategoryText);
+        }
+    }
+
+    [Fact]
+    public async Task ShouldFilterGamesByPublisher()
+    {
+        // Navigate to homepage and wait for games to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Verify publishers dropdown loaded real options
+        var publisherSelect = Page.GetByTestId("filter-publisher");
+        var publisherOptions = await publisherSelect.Locator("option").AllAsync();
+        Assert.True(publisherOptions.Count > 1, "Publisher dropdown must have options beyond 'All Publishers'");
+
+        // Select the first real publisher
+        var firstPublisherText = (await publisherOptions[1].InnerTextAsync()).Trim();
+        var firstPublisherValue = await publisherOptions[1].GetAttributeAsync("value");
+        await publisherSelect.SelectOptionAsync(new SelectOptionValue { Value = firstPublisherValue });
+
+        // Wait for the grid to refresh
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Every visible publisher badge must match the selected publisher
+        var publisherBadges = Page.GetByTestId("game-publisher");
+        var badgeCount = await publisherBadges.CountAsync();
+        Assert.True(badgeCount > 0, "Filtered results must include at least one game with a publisher badge");
+
+        for (var i = 0; i < badgeCount; i++)
+        {
+            await Expect(publisherBadges.Nth(i)).ToContainTextAsync(firstPublisherText);
+        }
+    }
+
+    [Fact]
+    public async Task ShouldFilterGamesByCategoryAndPublisherCombined()
+    {
+        // Navigate to homepage and wait for games to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        var categorySelect = Page.GetByTestId("filter-category");
+        var publisherSelect = Page.GetByTestId("filter-publisher");
+
+        var categoryOptions = await categorySelect.Locator("option").AllAsync();
+        var publisherOptions = await publisherSelect.Locator("option").AllAsync();
+
+        Assert.True(categoryOptions.Count > 1, "Category dropdown must have options beyond 'All Categories'");
+        Assert.True(publisherOptions.Count > 1, "Publisher dropdown must have options beyond 'All Publishers'");
+
+        // Apply both filters
+        var selectedCategoryText = (await categoryOptions[1].InnerTextAsync()).Trim();
+        var selectedPublisherText = (await publisherOptions[1].InnerTextAsync()).Trim();
+
+        await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = await categoryOptions[1].GetAttributeAsync("value") });
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        await publisherSelect.SelectOptionAsync(new SelectOptionValue { Value = await publisherOptions[1].GetAttributeAsync("value") });
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Results should either be an empty state or cards that match both filters
+        var gameCards = Page.GetByTestId("game-card");
+        var cardCount = await gameCards.CountAsync();
+
+        for (var i = 0; i < cardCount; i++)
+        {
+            var card = gameCards.Nth(i);
+            var categoryBadge = card.GetByTestId("game-category");
+            var publisherBadge = card.GetByTestId("game-publisher");
+
+            if (await categoryBadge.IsVisibleAsync())
+                await Expect(categoryBadge).ToContainTextAsync(selectedCategoryText);
+
+            if (await publisherBadge.IsVisibleAsync())
+                await Expect(publisherBadge).ToContainTextAsync(selectedPublisherText);
+        }
+    }
+
+    [Fact]
+    public async Task ShouldShowClearButtonOnlyWhenFilterIsActive()
+    {
+        // Navigate to homepage and wait for games to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Clear button should not be visible with no filters
+        await Expect(Page.GetByTestId("filter-clear-button")).Not.ToBeVisibleAsync();
+
+        // Select a category — clear button must appear
+        var categorySelect = Page.GetByTestId("filter-category");
+        var categoryOptions = await categorySelect.Locator("option").AllAsync();
+        Assert.True(categoryOptions.Count > 1, "Category dropdown must have options beyond 'All Categories'");
+
+        await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = await categoryOptions[1].GetAttributeAsync("value") });
+        await Expect(Page.GetByTestId("filter-clear-button")).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task ShouldClearFiltersAndRestoreAllGames()
+    {
+        // Navigate to homepage and wait for games to load
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Record initial full count
+        var initialCount = await Page.GetByTestId("game-card").CountAsync();
+        Assert.True(initialCount > 0, "There must be at least one game to test filtering");
+
+        // Apply a category filter
+        var categorySelect = Page.GetByTestId("filter-category");
+        var categoryOptions = await categorySelect.Locator("option").AllAsync();
+        Assert.True(categoryOptions.Count > 1, "Category dropdown must have options beyond 'All Categories'");
+
+        await categorySelect.SelectOptionAsync(new SelectOptionValue { Value = await categoryOptions[1].GetAttributeAsync("value") });
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Click the clear button (single click — triggers single load)
+        await Page.GetByTestId("filter-clear-button").ClickAsync();
+
+        // Wait for the full list to be restored
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Full count should be restored and clear button hidden
+        var restoredCount = await Page.GetByTestId("game-card").CountAsync();
+        Assert.Equal(initialCount, restoredCount);
+        await Expect(Page.GetByTestId("filter-clear-button")).Not.ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task FilterDropdownsShouldBeKeyboardAccessible()
+    {
+        // Navigate to homepage
+        await Page.GotoAsync("/");
+        await Page.WaitForSelectorAsync("[data-testid='games-grid']", new() { Timeout = 15000 });
+
+        // Both dropdowns should have accessible labels
+        var categorySelect = Page.GetByLabel("Filter games by category");
+        var publisherSelect = Page.GetByLabel("Filter games by publisher");
+
+        await Expect(categorySelect).ToBeVisibleAsync();
+        await Expect(publisherSelect).ToBeVisibleAsync();
+
+        // Both should be focusable and interactive via keyboard
+        await categorySelect.FocusAsync();
+        await Expect(categorySelect).ToBeFocusedAsync();
+
+        await publisherSelect.FocusAsync();
+        await Expect(publisherSelect).ToBeFocusedAsync();
+    }
+
+    private static ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
+    private static IPageAssertions Expect(IPage page) => Assertions.Expect(page);
+}

--- a/client/TailspinToys.Web/Components/Shared/GameCard.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameCard.razor
@@ -8,19 +8,19 @@
         <div class="relative z-10">
             <h3 data-testid="game-title" class="text-xl font-semibold text-slate-100 mb-2 group-hover:text-blue-400 transition-colors">@Game.Title</h3>
 
-            @if (!string.IsNullOrWhiteSpace(Game.CategoryName) || !string.IsNullOrWhiteSpace(Game.PublisherName))
+            @if (Game.Category is not null || Game.Publisher is not null)
             {
                 <div class="flex gap-2 mb-3">
-                    @if (!string.IsNullOrWhiteSpace(Game.CategoryName))
+                    @if (Game.Category is not null)
                     {
                         <span class="text-xs font-medium px-2.5 py-0.5 rounded bg-blue-900/60 text-blue-300" data-testid="game-category">
-                            @Game.CategoryName
+                            @Game.Category.Name
                         </span>
                     }
-                    @if (!string.IsNullOrWhiteSpace(Game.PublisherName))
+                    @if (Game.Publisher is not null)
                     {
                         <span class="text-xs font-medium px-2.5 py-0.5 rounded bg-purple-900/60 text-purple-300" data-testid="game-publisher">
-                            @Game.PublisherName
+                            @Game.Publisher.Name
                         </span>
                     }
                 </div>

--- a/client/TailspinToys.Web/Components/Shared/GameFilterPanel.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameFilterPanel.razor
@@ -7,7 +7,7 @@
 @inject IHttpClientFactory HttpClientFactory
 @using TailspinToys.Web.Models
 
-<div data-testid="game-filter-panel" class="flex flex-wrap gap-4 mb-6 items-end">
+<div data-testid="game-filter-panel" data-interactive="@(_isInteractive ? "true" : null)" class="flex flex-wrap gap-4 mb-6 items-end">
 
     <div class="flex flex-col gap-1">
         <label for="filter-category" class="text-sm font-medium text-slate-300">Category</label>
@@ -76,6 +76,7 @@
 
     private List<Category> categories = [];
     private List<Publisher> publishers = [];
+    private bool _isInteractive = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -109,5 +110,21 @@
         // Invoke a single combined callback so the parent can reset both IDs
         // and trigger a single re-fetch — avoids two concurrent LoadGames calls.
         await OnClearFilters.InvokeAsync();
+    }
+
+    /// <summary>
+    /// Sets data-interactive="true" on the panel container after the Blazor interactive
+    /// circuit connects. OnAfterRenderAsync(firstRender) does NOT run during SSR, so this
+    /// attribute is a reliable signal that the circuit is fully connected and event
+    /// handlers are wired up.
+    /// </summary>
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _isInteractive = true;
+            StateHasChanged();
+        }
+        return Task.CompletedTask;
     }
 }

--- a/client/TailspinToys.Web/Components/Shared/GameFilterPanel.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameFilterPanel.razor
@@ -1,0 +1,113 @@
+@* GameFilterPanel.razor
+   A filter panel component that provides category and publisher dropdowns for
+   filtering the game list. Emits events when selections change so the parent
+   component can re-fetch data. *@
+
+@rendermode InteractiveServer
+@inject IHttpClientFactory HttpClientFactory
+@using TailspinToys.Web.Models
+
+<div data-testid="game-filter-panel" class="flex flex-wrap gap-4 mb-6 items-end">
+
+    <div class="flex flex-col gap-1">
+        <label for="filter-category" class="text-sm font-medium text-slate-300">Category</label>
+        <select id="filter-category"
+                data-testid="filter-category"
+                value="@SelectedCategoryId"
+                @onchange="OnCategoryChanged"
+                aria-label="Filter games by category"
+                class="bg-slate-700 border border-slate-600 text-slate-100 text-sm rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-w-[160px]">
+            <option value="0">All Categories</option>
+            @foreach (var category in categories)
+            {
+                <option value="@category.Id">@category.Name</option>
+            }
+        </select>
+    </div>
+
+    <div class="flex flex-col gap-1">
+        <label for="filter-publisher" class="text-sm font-medium text-slate-300">Publisher</label>
+        <select id="filter-publisher"
+                data-testid="filter-publisher"
+                value="@SelectedPublisherId"
+                @onchange="OnPublisherChanged"
+                aria-label="Filter games by publisher"
+                class="bg-slate-700 border border-slate-600 text-slate-100 text-sm rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-w-[160px]">
+            <option value="0">All Publishers</option>
+            @foreach (var publisher in publishers)
+            {
+                <option value="@publisher.Id">@publisher.Name</option>
+            }
+        </select>
+    </div>
+
+    @if (SelectedCategoryId != 0 || SelectedPublisherId != 0)
+    {
+        <button data-testid="filter-clear-button"
+                @onclick="ClearFilters"
+                aria-label="Clear all filters"
+                class="px-4 py-2 bg-slate-600 hover:bg-slate-500 text-slate-100 text-sm rounded-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 self-end">
+            Clear Filters
+        </button>
+    }
+
+</div>
+
+@code {
+    /// <summary>Currently selected category ID. 0 means no filter.</summary>
+    [Parameter]
+    public int SelectedCategoryId { get; set; }
+
+    /// <summary>Currently selected publisher ID. 0 means no filter.</summary>
+    [Parameter]
+    public int SelectedPublisherId { get; set; }
+
+    /// <summary>Raised when the category selection changes, providing the new category ID (0 = all).</summary>
+    [Parameter]
+    public EventCallback<int> SelectedCategoryIdChanged { get; set; }
+
+    /// <summary>Raised when the publisher selection changes, providing the new publisher ID (0 = all).</summary>
+    [Parameter]
+    public EventCallback<int> SelectedPublisherIdChanged { get; set; }
+
+    /// <summary>Raised when the user clicks Clear Filters, allowing the parent to reset both filters atomically.</summary>
+    [Parameter]
+    public EventCallback OnClearFilters { get; set; }
+
+    private List<Category> categories = [];
+    private List<Publisher> publishers = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        var client = HttpClientFactory.CreateClient("API");
+
+        try
+        {
+            categories = await client.GetFromJsonAsync<List<Category>>("api/categories") ?? [];
+            publishers = await client.GetFromJsonAsync<List<Publisher>>("api/publishers") ?? [];
+        }
+        catch
+        {
+            // Silently degrade — filters will be empty but the game list still works
+        }
+    }
+
+    private async Task OnCategoryChanged(ChangeEventArgs e)
+    {
+        var id = int.TryParse(e.Value?.ToString(), out var parsed) ? parsed : 0;
+        await SelectedCategoryIdChanged.InvokeAsync(id);
+    }
+
+    private async Task OnPublisherChanged(ChangeEventArgs e)
+    {
+        var id = int.TryParse(e.Value?.ToString(), out var parsed) ? parsed : 0;
+        await SelectedPublisherIdChanged.InvokeAsync(id);
+    }
+
+    private async Task ClearFilters()
+    {
+        // Invoke a single combined callback so the parent can reset both IDs
+        // and trigger a single re-fetch — avoids two concurrent LoadGames calls.
+        await OnClearFilters.InvokeAsync();
+    }
+}

--- a/client/TailspinToys.Web/Components/Shared/GameList.razor
+++ b/client/TailspinToys.Web/Components/Shared/GameList.razor
@@ -4,6 +4,13 @@
 <div>
     <h2 class="text-2xl font-medium mb-6 text-slate-100">Featured Games</h2>
 
+    <GameFilterPanel
+        SelectedCategoryId="@selectedCategoryId"
+        SelectedPublisherId="@selectedPublisherId"
+        SelectedCategoryIdChanged="OnCategoryChanged"
+        SelectedPublisherIdChanged="OnPublisherChanged"
+        OnClearFilters="OnClearFilters" />
+
     @if (isLoading)
     {
         <LoadingSkeleton />
@@ -31,13 +38,44 @@
     private Game[]? games;
     private bool isLoading = true;
     private string? errorMessage;
+    private int selectedCategoryId;
+    private int selectedPublisherId;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadGames();
+    }
+
+    private async Task OnCategoryChanged(int categoryId)
+    {
+        selectedCategoryId = categoryId;
+        await LoadGames();
+    }
+
+    private async Task OnPublisherChanged(int publisherId)
+    {
+        selectedPublisherId = publisherId;
+        await LoadGames();
+    }
+
+    private async Task OnClearFilters()
+    {
+        // Reset both filters atomically before fetching — avoids two concurrent loads.
+        selectedCategoryId = 0;
+        selectedPublisherId = 0;
+        await LoadGames();
+    }
+
+    private async Task LoadGames()
+    {
+        isLoading = true;
+        errorMessage = null;
+
         try
         {
+            var url = BuildGamesUrl();
             var client = HttpClientFactory.CreateClient("API");
-            var response = await client.GetAsync("api/games");
+            var response = await client.GetAsync(url);
 
             if (response.IsSuccessStatusCode)
             {
@@ -56,5 +94,19 @@
         {
             isLoading = false;
         }
+    }
+
+    private string BuildGamesUrl()
+    {
+        var url = "api/games";
+        var queryParts = new List<string>();
+
+        if (selectedCategoryId != 0)
+            queryParts.Add($"categoryId={selectedCategoryId}");
+
+        if (selectedPublisherId != 0)
+            queryParts.Add($"publisherId={selectedPublisherId}");
+
+        return queryParts.Count > 0 ? $"{url}?{string.Join("&", queryParts)}" : url;
     }
 }

--- a/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestCategoriesRoutes.cs
@@ -1,0 +1,129 @@
+// Integration tests for the categories API routes.
+// Verifies that GET /api/categories returns the correct category data.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TailspinToys.Api;
+using TailspinToys.Api.Models;
+
+namespace TailspinToys.Api.Tests;
+
+public class TestCategoriesRoutes : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    private static readonly string[] TestCategoryNames = ["Strategy", "Card Game", "Puzzle"];
+
+    private const string CategoriesApiPath = "/api/categories";
+
+    public TestCategoriesRoutes()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"TestDb_{Guid.NewGuid()}.db");
+        var connectionString = $"Data Source={_dbPath}";
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = connectionString
+                    });
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        SeedTestData(db);
+    }
+
+    private void SeedTestData(TailspinToysContext db)
+    {
+        db.Categories.AddRange(TestCategoryNames.Select(name => new Category { Name = name }));
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetCategories_ReturnsAllCategories()
+    {
+        // Act
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(TestCategoryNames.Length, data.Count);
+
+        var returnedNames = data.Select(c => c["name"]?.ToString()).OrderBy(n => n).ToList();
+        var expectedNames = TestCategoryNames.OrderBy(n => n).ToList();
+        Assert.Equal(expectedNames, returnedNames);
+    }
+
+    [Fact]
+    public async Task GetCategories_ReturnsIdAndName()
+    {
+        // Act
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        var category = data[0];
+        Assert.True(category.ContainsKey("id"), "Response should contain 'id'");
+        Assert.True(category.ContainsKey("name"), "Response should contain 'name'");
+        Assert.Equal(2, category.Count);
+
+        var id = Assert.IsType<JsonElement>(category["id"]);
+        Assert.True(id.GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task GetCategories_EmptyDatabase_ReturnsEmptyList()
+    {
+        // Clear all categories
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Categories.RemoveRange(db.Categories);
+        db.SaveChanges();
+
+        // Act
+        var response = await _client.GetAsync(CategoriesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; ignore if the file is locked or already deleted
+        }
+    }
+}

--- a/server/TailspinToys.Api.Tests/TestGamesRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestGamesRoutes.cs
@@ -232,6 +232,103 @@ public class TestGamesRoutes : IDisposable
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task GetGames_FilterByCategory_ReturnsMatchingGames()
+    {
+        // Get category IDs from the database
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        var strategyCategory = db.Categories.First(c => c.Name == (string)TestCategories[0]["name"]);
+
+        // Act
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId={strategyCategory.Id}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Single(data);
+        Assert.Equal(TestGames[0]["title"].ToString(), data[0]["title"]?.ToString());
+    }
+
+    [Fact]
+    public async Task GetGames_FilterByPublisher_ReturnsMatchingGames()
+    {
+        // Get publisher IDs from the database
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        var publisher = db.Publishers.First(p => p.Name == (string)TestPublishers[1]["name"]);
+
+        // Act
+        var response = await _client.GetAsync($"{GamesApiPath}?publisherId={publisher.Id}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Single(data);
+        Assert.Equal(TestGames[1]["title"].ToString(), data[0]["title"]?.ToString());
+    }
+
+    [Fact]
+    public async Task GetGames_FilterByCategoryAndPublisher_ReturnsMatchingGames()
+    {
+        // Get both IDs from the database
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        var category = db.Categories.First(c => c.Name == (string)TestCategories[0]["name"]);
+        var publisher = db.Publishers.First(p => p.Name == (string)TestPublishers[0]["name"]);
+
+        // Act
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId={category.Id}&publisherId={publisher.Id}");
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Single(data);
+        Assert.Equal(TestGames[0]["title"].ToString(), data[0]["title"]?.ToString());
+    }
+
+    [Fact]
+    public async Task GetGames_FilterByCategory_NoMatches_ReturnsEmptyList()
+    {
+        // Act - use a category ID that doesn't exist
+        var response = await _client.GetAsync($"{GamesApiPath}?categoryId=99999");
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    [Fact]
+    public async Task GetGames_FilterByPublisher_NoMatches_ReturnsEmptyList()
+    {
+        // Act - use a publisher ID that doesn't exist
+        var response = await _client.GetAsync($"{GamesApiPath}?publisherId=99999");
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    [Fact]
+    public async Task GetGames_NoFilterParams_ReturnsAllGames()
+    {
+        // Act - no query params should return all games
+        var response = await _client.GetAsync(GamesApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(TestGames.Length, data.Count);
+    }
+
     public void Dispose()
     {
         _client.Dispose();

--- a/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
+++ b/server/TailspinToys.Api.Tests/TestPublishersRoutes.cs
@@ -1,0 +1,129 @@
+// Integration tests for the publishers API routes.
+// Verifies that GET /api/publishers returns the correct publisher data.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TailspinToys.Api;
+using TailspinToys.Api.Models;
+
+namespace TailspinToys.Api.Tests;
+
+public class TestPublishersRoutes : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    private static readonly string[] TestPublisherNames = ["DevGames Inc", "Scrum Masters", "Agile Arcade"];
+
+    private const string PublishersApiPath = "/api/publishers";
+
+    public TestPublishersRoutes()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"TestDb_{Guid.NewGuid()}.db");
+        var connectionString = $"Data Source={_dbPath}";
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+
+                builder.ConfigureAppConfiguration((context, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = connectionString
+                    });
+                });
+            });
+
+        _client = _factory.CreateClient();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        SeedTestData(db);
+    }
+
+    private void SeedTestData(TailspinToysContext db)
+    {
+        db.Publishers.AddRange(TestPublisherNames.Select(name => new Publisher { Name = name }));
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetPublishers_ReturnsAllPublishers()
+    {
+        // Act
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Equal(TestPublisherNames.Length, data.Count);
+
+        var returnedNames = data.Select(p => p["name"]?.ToString()).OrderBy(n => n).ToList();
+        var expectedNames = TestPublisherNames.OrderBy(n => n).ToList();
+        Assert.Equal(expectedNames, returnedNames);
+    }
+
+    [Fact]
+    public async Task GetPublishers_ReturnsIdAndName()
+    {
+        // Act
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.NotEmpty(data);
+
+        var publisher = data[0];
+        Assert.True(publisher.ContainsKey("id"), "Response should contain 'id'");
+        Assert.True(publisher.ContainsKey("name"), "Response should contain 'name'");
+        Assert.Equal(2, publisher.Count);
+
+        var id = Assert.IsType<JsonElement>(publisher["id"]);
+        Assert.True(id.GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task GetPublishers_EmptyDatabase_ReturnsEmptyList()
+    {
+        // Clear all publishers
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TailspinToysContext>();
+        db.Publishers.RemoveRange(db.Publishers);
+        db.SaveChanges();
+
+        // Act
+        var response = await _client.GetAsync(PublishersApiPath);
+        var data = await response.Content.ReadFromJsonAsync<List<object>>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(data);
+        Assert.Empty(data);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        try
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; ignore if the file is locked or already deleted
+        }
+    }
+}

--- a/server/TailspinToys.Api/Program.cs
+++ b/server/TailspinToys.Api/Program.cs
@@ -54,6 +54,8 @@ app.UseCors();
 
 // Register routes
 app.MapGamesRoutes();
+app.MapPublishersRoutes();
+app.MapCategoriesRoutes();
 
 app.Run();
 

--- a/server/TailspinToys.Api/Routes/CategoriesRoutes.cs
+++ b/server/TailspinToys.Api/Routes/CategoriesRoutes.cs
@@ -1,0 +1,27 @@
+// Routes for the categories API resource.
+// Provides endpoints to retrieve category information used for filtering games.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace TailspinToys.Api.Routes;
+
+/// <summary>Extension methods to register category API routes.</summary>
+public static class CategoriesRoutes
+{
+    /// <summary>Maps all category-related routes onto the application.</summary>
+    /// <param name="app">The <see cref="WebApplication"/> to register routes on.</param>
+    public static void MapCategoriesRoutes(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/categories");
+
+        group.MapGet("/", async (TailspinToysContext db) =>
+        {
+            var categories = await db.Categories
+                .OrderBy(c => c.Id)
+                .Select(c => new { c.Id, c.Name })
+                .ToListAsync();
+
+            return Results.Ok(categories);
+        });
+    }
+}

--- a/server/TailspinToys.Api/Routes/GamesRoutes.cs
+++ b/server/TailspinToys.Api/Routes/GamesRoutes.cs
@@ -1,22 +1,35 @@
+// Routes for the games API resource.
+// Provides endpoints to list, filter, and retrieve individual game records.
+
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using TailspinToys.Api;
 
 namespace TailspinToys.Api.Routes;
 
+/// <summary>Extension methods to register game API routes.</summary>
 public static class GamesRoutes
 {
+    /// <summary>Maps all game-related routes onto the application.</summary>
+    /// <param name="app">The <see cref="WebApplication"/> to register routes on.</param>
     public static void MapGamesRoutes(this WebApplication app)
     {
         var group = app.MapGroup("/api/games");
 
-        group.MapGet("/", async (TailspinToysContext db) =>
+        group.MapGet("/", async (int? categoryId, int? publisherId, TailspinToysContext db) =>
         {
-            var games = await db.Games
+            var query = db.Games
                 .Include(g => g.Publisher)
                 .Include(g => g.Category)
-                .OrderBy(g => g.Id)
-                .ToListAsync();
+                .AsQueryable();
+
+            if (categoryId.HasValue)
+                query = query.Where(g => g.CategoryId == categoryId.Value);
+
+            if (publisherId.HasValue)
+                query = query.Where(g => g.PublisherId == publisherId.Value);
+
+            var games = await query.OrderBy(g => g.Id).ToListAsync();
 
             return Results.Ok(games.Select(g => g.ToDict()));
         });

--- a/server/TailspinToys.Api/Routes/PublishersRoutes.cs
+++ b/server/TailspinToys.Api/Routes/PublishersRoutes.cs
@@ -1,3 +1,27 @@
+// Routes for the publishers API resource.
+// Provides endpoints to retrieve publisher information.
+
+using Microsoft.EntityFrameworkCore;
+
 namespace TailspinToys.Api.Routes;
 
-// Publishers routes - placeholder for future implementation
+/// <summary>Extension methods to register publisher API routes.</summary>
+public static class PublishersRoutes
+{
+    /// <summary>Maps all publisher-related routes onto the application.</summary>
+    /// <param name="app">The <see cref="WebApplication"/> to register routes on.</param>
+    public static void MapPublishersRoutes(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/publishers");
+
+        group.MapGet("/", async (TailspinToysContext db) =>
+        {
+            var publishers = await db.Publishers
+                .OrderBy(p => p.Id)
+                .Select(p => new { p.Id, p.Name })
+                .ToListAsync();
+
+            return Results.Ok(publishers);
+        });
+    }
+}


### PR DESCRIPTION
## Why

Users currently have no way to narrow down the game list beyond scrolling through all available titles. This PR implements the filtering feature requested in issue #1, allowing users to quickly find games by category and/or publisher.

Closes #1

## Changes

- **New** `GET /api/categories` endpoint returning all categories as `[{id, name}]`
- **Updated** `GET /api/games` to accept optional `?categoryId=` and `?publisherId=` query params (filterable individually or combined)
- **New** `GameFilterPanel.razor` component with accessible category and publisher dropdowns and a conditional "Clear Filters" button
- **Updated** `GameList.razor` to embed the filter panel and re-fetch from the API on filter change
- **New/updated tests**: 3 categories endpoint tests, 6 games filter tests, 7 Playwright E2E filter tests
- **Docs**: README Features section, updated Playwright `data-testid` reference

## Backend filtering

The `GET /api/games` endpoint now accepts optional query parameters:

```
GET /api/games?categoryId=2
GET /api/games?publisherId=3
GET /api/games?categoryId=2&publisherId=3
```

Filtering is composed via EF Core `.Where()` — only the provided params are applied:

```csharp
group.MapGet("/", async (int? categoryId, int? publisherId, TailspinToysContext db) =>
{
    var query = db.Games
        .Include(g => g.Publisher)
        .Include(g => g.Category)
        .AsQueryable();

    if (categoryId.HasValue)
        query = query.Where(g => g.CategoryId == categoryId.Value);

    if (publisherId.HasValue)
        query = query.Where(g => g.PublisherId == publisherId.Value);

    var games = await query.OrderBy(g => g.Id).ToListAsync();
    return Results.Ok(games.Select(g => g.ToDict()));
});
```

## Frontend filter panel

`GameFilterPanel.razor` uses an `OnClearFilters` EventCallback (instead of two separate callbacks) to reset both filters atomically in a single re-fetch — avoiding potential race conditions from concurrent `LoadGames` calls.

```razor
<GameFilterPanel
    SelectedCategoryId="@selectedCategoryId"
    SelectedPublisherId="@selectedPublisherId"
    SelectedCategoryIdChanged="OnCategoryChanged"
    SelectedPublisherIdChanged="OnPublisherChanged"
    OnClearFilters="OnClearFilters" />
```

## Accessibility

- Both dropdowns have `<label>` elements and `aria-label` attributes
- All interactive elements have `data-testid` attributes
- Keyboard focusable and navigable
